### PR TITLE
解决查询参数为中文时，返回无结果bug

### DIFF
--- a/src/main/java/cn/benma666/kettle/mytuils/KettleUtils.java
+++ b/src/main/java/cn/benma666/kettle/mytuils/KettleUtils.java
@@ -398,6 +398,7 @@ public class KettleUtils {
                 poolp.put("timeBetweenEvictionRunsMillis", 5*60*1000);
                 poolp.put("validationQuery", validationQuery);
                 poolp.put("maxActive", 20);
+		poolp.put("characterEncoding", "utf-8");
                 dm.setConnectionPoolingProperties(poolp );
             }
             


### PR DESCRIPTION
解决查询参数为中文时，返回无结果bug